### PR TITLE
Set view page and comment redo

### DIFF
--- a/eorlive_prototype/app/comments.py
+++ b/eorlive_prototype/app/comments.py
@@ -1,0 +1,51 @@
+from flask import render_template, g, make_response, request
+from app.flask_app import app, db
+from app import models
+
+@app.route('/get_all_comments')
+def get_all_comments():
+    threads = models.Thread.query.all()
+
+    for thread in threads:
+        thread.comments = models.Comment.query.filter(models.Comment.thread_id == thread.id).all()
+
+    return render_template('comments_list.html', threads=threads)
+
+@app.route('/thread_reply', methods = ['POST'])
+def thread_reply():
+    if g.user is not None and g.user.is_authenticated():
+        thread_id = request.form['thread_id']
+        text = request.form['text']
+
+        new_comment = models.Comment()
+        new_comment.thread_id = thread_id
+        new_comment.text = text
+        new_comment.username = g.user.username
+        db.session.add(new_comment)
+        db.session.commit()
+        return make_response("Success", 200)
+    else:
+        return make_response("You need to be logged in to post a comment.", 401)
+
+@app.route('/new_thread', methods = ['POST'])
+def new_thread():
+    if g.user is not None and g.user.is_authenticated():
+        title = request.form['title']
+        text = request.form['text']
+
+        new_thread = models.Thread()
+        new_thread.title = title
+        new_thread.username = g.user.username
+        db.session.add(new_thread)
+        db.session.flush()
+        db.session.refresh(new_thread) # So we can get the new thread's id
+
+        first_comment = models.Comment()
+        first_comment.text = text
+        first_comment.username = g.user.username
+        first_comment.thread_id = new_thread.id
+        db.session.add(first_comment)
+        db.session.commit()
+        return make_response("Success", 200)
+    else:
+        return make_response("You need to be logged in to create a thread.", 401)

--- a/eorlive_prototype/app/db_utils.py
+++ b/eorlive_prototype/app/db_utils.py
@@ -1,0 +1,23 @@
+from flask import g
+from datetime import datetime
+
+def send_query(db, query):
+    cur = db.cursor()
+    cur.execute(query)
+    return cur
+
+def get_gps_utc_constants():
+    leap_seconds_result = send_query(g.eor_db,
+        "SELECT leap_seconds FROM leap_seconds ORDER BY leap_seconds DESC LIMIT 1").fetchone()
+
+    leap_seconds = leap_seconds_result[0]
+
+    GPS_LEAP_SECONDS_OFFSET = leap_seconds - 19
+
+    jan_1_1970 = datetime(1970, 1, 1)
+
+    jan_6_1980 = datetime(1980, 1, 6)
+
+    GPS_UTC_DELTA = (jan_6_1980 - jan_1_1970).total_seconds()
+
+    return (GPS_LEAP_SECONDS_OFFSET, GPS_UTC_DELTA)

--- a/eorlive_prototype/app/histogram_utils.py
+++ b/eorlive_prototype/app/histogram_utils.py
@@ -1,0 +1,73 @@
+from app import db_utils, models
+from flask import g
+
+def get_error_counts(start_gps, end_gps):
+    error_counts = []
+    error_count = 0
+
+    obscontroller_response = db_utils.send_query(g.eor_db, '''SELECT FLOOR(reference_time) AS reference_time
+                            FROM obscontroller_log
+                            WHERE reference_time >= {} AND reference_time <= {}
+                            ORDER BY reference_time ASC'''.format(start_gps, end_gps)).fetchall()
+
+    recvstatuspolice_response = db_utils.send_query(g.eor_db, '''SELECT FLOOR(reference_time) AS reference_time
+                            FROM recvstatuspolice_log
+                            WHERE reference_time >= {} AND reference_time <= {}
+                            ORDER BY reference_time ASC'''.format(start_gps, end_gps)).fetchall()
+
+    GPS_LEAP_SECONDS_OFFSET, GPS_UTC_DELTA = db_utils.get_gps_utc_constants()
+
+    prev_time = 0
+
+    for error in obscontroller_response:
+        utc_millis = int((error[0] - GPS_LEAP_SECONDS_OFFSET + GPS_UTC_DELTA) * 1000)
+        if utc_millis == prev_time:
+            error_counts[-1][1] += 1
+        else:
+            error_counts.append([utc_millis, 1])
+            prev_time = utc_millis
+        error_count += 1
+
+    prev_time = 0
+
+    for error in recvstatuspolice_response:
+        utc_millis = int((error[0] - GPS_LEAP_SECONDS_OFFSET + GPS_UTC_DELTA) * 1000)
+        if utc_millis == prev_time:
+            error_counts[-1][1] += 1
+        else:
+            error_counts.append([utc_millis, 1])
+            prev_time = utc_millis
+        error_count += 1
+
+    error_counts.sort(key=lambda error: error[0])
+
+    return (error_counts, error_count)
+
+def get_observation_counts(start_gps, end_gps):
+    response = db_utils.send_query(g.eor_db, '''SELECT starttime
+                FROM mwa_setting
+                WHERE starttime >= {} AND starttime <= {}
+                AND projectid='G0009'
+                ORDER BY starttime ASC'''.format(start_gps, end_gps)).fetchall()
+
+    GPS_LEAP_SECONDS_OFFSET, GPS_UTC_DELTA = db_utils.get_gps_utc_constants()
+
+    observation_counts = []
+
+    for observation in response:
+        utc_millis = int((observation[0] - GPS_LEAP_SECONDS_OFFSET + GPS_UTC_DELTA) * 1000)
+        observation_counts.append([utc_millis, 1])
+
+    return observation_counts
+
+def get_plot_bands(the_set):
+    flagged_subsets = models.FlaggedSubset.query.filter(models.FlaggedSubset.set_id == the_set.id).all()
+
+    GPS_LEAP_SECONDS_OFFSET, GPS_UTC_DELTA = db_utils.get_gps_utc_constants()
+
+    plot_bands = [{'from': int((flagged_subset.start - GPS_LEAP_SECONDS_OFFSET + GPS_UTC_DELTA) * 1000),
+        'to': int((flagged_subset.end - GPS_LEAP_SECONDS_OFFSET + GPS_UTC_DELTA) * 1000),
+        'color': 'yellow'}
+        for flagged_subset in flagged_subsets]
+
+    return plot_bands

--- a/eorlive_prototype/app/models.py
+++ b/eorlive_prototype/app/models.py
@@ -45,7 +45,6 @@ class Set(db.Model):
     name = db.Column(db.String(50))
     start = db.Column(db.Integer)
     end = db.Column(db.Integer)
-    comments = db.relationship('Comment', backref='range', lazy='dynamic')
 
 class FlaggedSubset(db.Model):
     id = db.Column(db.Integer, primary_key=True)
@@ -63,7 +62,7 @@ class GraphData(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     # Store a 'created_on' string field for the current time that is automatically inserted with a new entry into the database.
     # We're using UTC time, so that's why there is a Z at the end of the string.
-    created_on = db.Column(db.String(20), default=datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'))
+    created_on = db.Column(db.DateTime, default=datetime.utcnow)
     hours_scheduled = db.Column(db.Float)
     hours_observed = db.Column(db.Float)
     hours_with_data = db.Column(db.Float)
@@ -81,9 +80,15 @@ class GraphData(db.Model):
             'data_transfer_rate': round(self.data_transfer_rate or 0., 4)
         }
 
+class Thread(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(100), nullable=False)
+    username = db.Column(db.String(32), db.ForeignKey('user.username'))
+    created_on = db.Column(db.DateTime, default=datetime.utcnow)
+
 class Comment(db.Model):
     id = db.Column(db.Integer, primary_key=True)
-    text = db.Column(db.String(1000), nullable=True)
+    thread_id = db.Column(db.Integer, db.ForeignKey('thread.id'))
+    text = db.Column(db.String(1000), nullable=False)
     username = db.Column(db.String(32), db.ForeignKey('user.username'))
-    set_id = db.Column(db.Integer, db.ForeignKey('set.id'))
-    created_on = db.Column(db.String(20), default=datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'))
+    created_on = db.Column(db.DateTime, default=datetime.utcnow)

--- a/eorlive_prototype/app/sets.py
+++ b/eorlive_prototype/app/sets.py
@@ -1,4 +1,4 @@
-from app import views, models
+from app import db_utils, models
 from app.flask_app import app, db
 from flask import request, g, make_response, jsonify
 
@@ -80,7 +80,7 @@ def upload_set():
 
         good_obs_ids.sort()
 
-        all_obs_ids_tuples = views.send_query(g.eor_db, '''SELECT starttime
+        all_obs_ids_tuples = db_utils.send_query(g.eor_db, '''SELECT starttime
                             FROM mwa_setting
                             WHERE starttime >= {} AND starttime <= {}
                             ORDER BY starttime ASC'''.format(good_obs_ids[0],
@@ -114,7 +114,7 @@ def download_set():
     if the_set is not None:
         flagged_subsets = models.FlaggedSubset.query.filter(models.FlaggedSubset.set_id == the_set.id).all()
 
-        all_obs_ids_tuples = views.send_query(g.eor_db, '''SELECT starttime
+        all_obs_ids_tuples = db_utils.send_query(g.eor_db, '''SELECT starttime
                             FROM mwa_setting
                             WHERE starttime >= {} AND starttime <= {}
                             ORDER BY starttime ASC'''.format(the_set.start,

--- a/eorlive_prototype/app/static/css/style.css
+++ b/eorlive_prototype/app/static/css/style.css
@@ -1,4 +1,4 @@
-#error_table, #set_construction_div {
+#error_table, #set_construction_div, #comments_div {
     width: 100%;
     max-width: 100%;
     max-height: 400px;
@@ -56,4 +56,90 @@ h2              { font-size: 1.2em; }
     padding: 10px;
     border-style: solid;
     border-width: 2px;
+}
+
+.arrow-r {
+    width: 0;
+    height: 0;
+    border-top: 5px solid transparent;
+    border-bottom: 5px solid transparent;
+    border-left: 5px solid #444;
+    margin-bottom: 4px;
+    margin-right: 7px;
+    margin-left: 3px;
+    display: inline-block;
+}
+
+.arrow-d {
+    width: 0;
+    height: 0;
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    border-top: 5px solid #444;
+    margin-bottom: 6px;
+    margin-right: 5px;
+    display: inline-block;
+}
+
+.collapse-container>:nth-child(odd) {
+    padding: 5px;
+    background-color: gray;
+    background-image: linear-gradient(bottom, gray 14%, #969696 70%);
+    background-image: -o-linear-gradient(bottom, gray 14%, #969696 70%);
+    background-image: -moz-linear-gradient(bottom, gray 14%, #969696 70%);
+    background-image: -webkit-linear-gradient(bottom, gray 14%, #969696 70%);
+    background-image: -ms-linear-gradient(bottom, gray 14%, #969696 70%);
+    border: 1px solid black;
+    margin: auto;
+}
+.collapse-container>:nth-child(even) {
+    background-color: white;
+    display: none;
+    -moz-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+    border: 1px solid black;
+}
+.collapse-container>:nth-child(even) p {
+    padding: 0px 5px;
+}
+
+.collapse-container>:nth-child(odd):hover {
+    cursor: pointer;
+    -moz-user-select: none; /* mozilla browsers */
+    -khtml-user-select: none; /* webkit browsers */
+}
+
+.collapse-container>:first-child {
+    border-radius: 4px 4px 0px 0px;
+}
+
+.collapse-container>:nth-last-child(2) {
+    border-radius: 0px 0px 3px 3px;
+}
+
+.collapse-container h1, .collapse-container h2, .collapse-container h3 {
+    color: #f9f9f9;
+}
+
+.replyButton {
+    background-color:#44c767;
+    border:1px solid #18ab29;
+    display:inline-block;
+    border-radius: 4px;
+    cursor:pointer;
+    color:#ffffff;
+    font-family:arial;
+    text-decoration:none;
+    text-shadow:0px 1px 0px #2f6627;
+    float: right;
+}
+
+.replyButton:hover {
+    background-color:#5cbf2a;
+}
+
+.replyButton:active {
+    position:relative;
+    top:1px;
 }

--- a/eorlive_prototype/app/static/js/collapsible.min.js
+++ b/eorlive_prototype/app/static/js/collapsible.min.js
@@ -1,0 +1,9 @@
+/*!
+* Collapsible.js 1.0.0
+* https://github.com/jordnkr/collapsible
+*
+* Copyright 2013, Jordan Ruedy
+* This content is released under the MIT license
+* http://opensource.org/licenses/MIT
+*/
+(function(e,t){e.fn.collapsible=function(t,n){var r={accordionUpSpeed:400,accordionDownSpeed:400,collapseSpeed:400,contentOpen:0,arrowRclass:"arrow-r",arrowDclass:"arrow-d",animate:true};if(typeof t==="object"){var i=e.extend(r,t)}else{var i=e.extend(r,n)}return this.each(function(){if(i.animate===false){i.accordionUpSpeed=0;i.accordionDownSpeed=0;i.collapseSpeed=0}var n=e(this).children(":even");var r=e(this).children(":odd");var s="accordion-active";switch(t){case"accordion-open":case"accordion":if(t==="accordion-open"){e(n[i.contentOpen]).children(":first-child").toggleClass(i.arrowRclass+" "+i.arrowDclass);e(r[i.contentOpen]).show().addClass(s)}e(n).click(function(){if(e(this).next().attr("class")===s){e(this).next().slideUp(i.accordionUpSpeed).removeClass(s);e(this).children(":first-child").toggleClass(i.arrowRclass+" "+i.arrowDclass)}else{e(n).children().removeClass(i.arrowDclass).addClass(i.arrowRclass);e(r).slideUp(i.accordionUpSpeed).removeClass(s);e(this).next().slideDown(i.accordionDownSpeed).addClass(s);e(this).children(":first-child").toggleClass(i.arrowRclass+" "+i.arrowDclass)}});break;case"default-open":default:if(t==="default-open"){e(n[i.contentOpen]).children(":first-child").toggleClass(i.arrowRclass+" "+i.arrowDclass);e(r[i.contentOpen]).show()}e(n).click(function(){e(this).children(":first-child").toggleClass(i.arrowRclass+" "+i.arrowDclass);e(this).next().slideToggle(i.collapseSpeed)});break}})}})(jQuery)

--- a/eorlive_prototype/app/static/js/index.js
+++ b/eorlive_prototype/app/static/js/index.js
@@ -38,6 +38,7 @@ $(function() {
     });
 
     getObservations();
+    getComments();
 });
 
 function getDateTimeString(now) {
@@ -80,7 +81,6 @@ function getObservations() {
     }
 
     $("#observations_summary").html("<img src='/static/images/ajax-loader.gif' class='loading'/>");
-    $("#comments_div").html("<img src='/static/images/ajax-loader.gif' class='loading'/>");
 
     // Make each date into a string of the format "YYYY-mm-ddTHH:MM:SSZ", which is the format used in the local database.
     var startUTC = startDate.toISOString().slice(0, 19) + "Z";
@@ -99,6 +99,22 @@ function getObservations() {
     var e = document.getElementById('filter_dropdown');
     var eVal = e.options[e.selectedIndex].value;
     renderSets(eVal, startUTC, endUTC);
+};
+
+function getComments() {
+    $("#comments_div").html("<img src='/static/images/ajax-loader.gif' class='loading'/>");
+
+    $.ajax({
+        type: "GET",
+        url: "/get_all_comments",
+        success: function(data) {
+            $("#comments_div").html(data);
+            $("#comments_list").collapsible({
+                animate: false
+            });
+        },
+        dataType: "html"
+    });
 };
 
 function getDate(datestr) {

--- a/eorlive_prototype/app/static/js/setsAndComments.js
+++ b/eorlive_prototype/app/static/js/setsAndComments.js
@@ -12,18 +12,6 @@ function renderSets(filterType, startUTC, endUTC) {
     });
 };
 
-function saveComment(set_id, comment_text) {
-    $.ajax({
-        type: "POST",
-        url: "/save_comment",
-        data: {'set_id': set_id, 'comment_text': comment_text},
-        success: function(data) {
-            $('#comments_div').html(data);
-        },
-        dataType: 'html'
-    });
-};
-
 function deleteSet(setName) {
     $.ajax({
         type: "POST",
@@ -31,20 +19,6 @@ function deleteSet(setName) {
         data: {'set_name': setName},
         success: function(data) {
             document.write(data);
-        },
-        dataType: 'html'
-    });
-};
-
-function renderComments(setName) {
-    $("#comments_div").html("<img src='/static/images/ajax-loader.gif' class='loading'/>");
-
-    $.ajax({
-        type: "POST",
-        url: "/get_comments",
-        data: {'set_name': setName},
-        success: function(data) {
-            $('#comments_div').html(data);
         },
         dataType: 'html'
     });

--- a/eorlive_prototype/app/templates/comment_reply.html
+++ b/eorlive_prototype/app/templates/comment_reply.html
@@ -1,0 +1,106 @@
+<div id="comment_reply" style="display:none;">
+    Reply to:&nbsp;<span id="replying_thread_name"></span>
+    <br>
+    <textarea id="reply_text" maxlength="1000" style="max-width:700px;max-height:150px;"></textarea>
+    <input id="replying_thread_id" type="hidden"/>
+    <br>
+    <button id="cancel_reply_button" type="button" onclick="cancelReply()">Cancel</button>
+    <button id="reply_button" type="button" onclick="replyToThread()">Reply</button>
+</div>
+<div id="new_thread" style="display:none;">
+    <span>Thread title</span>
+    <br>
+    <input id="new_thread_title" type="text" maxlength="100"/>
+    <br>
+    <span>Comment</span>
+    <br>
+    <textarea id="new_thread_comment" maxlength="1000" style="max-width:700px;max-height:150px;"></textarea>
+    <br>
+    <button id="cancel_new_button" type="button" onclick="cancelNewThread()">Cancel</button>
+    <button id="new_thread_button" type="button" onclick="createNewThread()">Create</button>
+</div>
+<script>
+    var setReplyButtons = function(disabled, text) {
+        $("#reply_button").prop('disabled', disabled);
+        $("#reply_button").html(text);
+        $("#cancel_reply_button").prop('disabled', disabled);
+    };
+
+    var setNewThreadButtons = function(disabled, text) {
+        $("#new_thread_button").prop('disabled', disabled);
+        $("#new_thread_button").html(text);
+        $("#cancel_new_button").prop('disabled', disabled);
+    };
+
+    var replyToThread = function() {
+        var thread_id = $("#replying_thread_id").val();
+
+        var reply = $("#reply_text").val();
+
+        if (reply.length === 0)
+            return;
+
+        setReplyButtons(true, "Working...");
+
+        $.ajax({
+            type: 'POST',
+            url: '/thread_reply',
+            data: {
+                thread_id: thread_id,
+                text: reply
+            },
+            success: function(data) {
+                getComments();
+                setReplyButtons(false, "Reply");
+                cancelReply();
+            },
+            error: function(xhr, status, error) {
+                setReplyButtons(false, "Reply");
+            },
+            dataType: "html"
+        });
+    };
+
+    var createNewThread = function() {
+        var title = $("#new_thread_title").val();
+
+        if (title.length === 0)
+            return;
+
+        var text = $("#new_thread_comment").val();
+
+        if (text.length === 0)
+            return;
+
+        setNewThreadButtons(true, "Working...");
+
+        $.ajax({
+            type: 'POST',
+            url: '/new_thread',
+            data: {
+                title: title,
+                text: text
+            },
+            success: function(data) {
+                getComments();
+                setNewThreadButtons(false, "Create");
+                cancelNewThread();
+            },
+            error: function(xhr, status, error) {
+                setNewThreadButtons(false, "Create");
+            },
+            dataType: "html"
+        });
+    };
+
+    var cancelReply = function() {
+        $("#reply_text").val(''); // Clear the text area.
+        $("#comment_reply").hide();
+    };
+
+    var cancelNewThread = function() {
+        $("#new_thread_title").val('');
+        $("#new_thread_comment").val('');
+        $("#new_thread").hide();
+    };
+</script>

--- a/eorlive_prototype/app/templates/comments_list.html
+++ b/eorlive_prototype/app/templates/comments_list.html
@@ -1,0 +1,41 @@
+<div id="comments_list" class="collapse-container">
+    {% if threads | length > 0 %}
+        {% for thread in threads %}
+            <h3>
+                <span class="arrow-r"></span>
+                {{ thread.title }} by {{ thread.username }} at {{ thread.created_on }}
+                {% if g.user and g.user.is_authenticated() %}
+                <button type="button" class="replyButton" onclick="reply(event, '{{thread.id}}', '{{thread.title}}')">
+                    Reply
+                </button>
+                {% endif %}
+            </h3>
+            <div>
+                {% for comment in thread.comments %}
+                    <h4>
+                        {{ comment.username }} @ {{ comment.created_on }}
+                    </h4>
+                    <p>{{ comment.text }}</p>
+                {% endfor %}
+            </div>
+        {% endfor %}
+    {% else %}
+        No comments
+    {% endif %}
+</div>
+<script>
+    var reply = function(event, thread_id, thread_name) {
+        // Stop the collapsible list from handling the click.
+        event.stopPropagation();
+
+        $("#replying_thread_id").val(thread_id);
+        $("#replying_thread_name").text(thread_name);
+        $("#new_thread").hide();
+        $("#comment_reply").show();
+    };
+
+    var newThread = function(event) {
+        $("#comment_reply").hide();
+        $("#new_thread").show();
+    };
+</script>

--- a/eorlive_prototype/app/templates/index.html
+++ b/eorlive_prototype/app/templates/index.html
@@ -75,4 +75,9 @@
         renderSets(currentData, startUTC, endUTC);
     };
 </script>
+<script src="http://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+<script src="../static/js/setsAndComments.js"></script>
+<script src="../static/js/jquery.datetimepicker.js"></script>
+<script src="../static/js/index.js"></script>
+<script src="../static/js/highcharts.js"></script>
 {% endblock %}

--- a/eorlive_prototype/app/templates/index.html
+++ b/eorlive_prototype/app/templates/index.html
@@ -29,6 +29,12 @@
                     <br>
                     <div id='observations_summary'></div>
                     <br>
+                    <span style="font-size:30px;">Comments</span>
+                    {% if g.user and g.user.is_authenticated() %}
+                    <button type="button" onclick="newThread()" class="replyButton" style="margin-top:12px;">New thread</button>
+                    {% endif %}
+                    <div id='comments_div'></div>
+                    {% include 'comment_reply.html' %}
                     <br>
                     <div id='data_amount_table'></div>
                 </td>
@@ -78,6 +84,7 @@
 <script src="http://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
 <script src="../static/js/setsAndComments.js"></script>
 <script src="../static/js/jquery.datetimepicker.js"></script>
+<script src="../static/js/collapsible.min.js"></script>
 <script src="../static/js/index.js"></script>
 <script src="../static/js/highcharts.js"></script>
 {% endblock %}

--- a/eorlive_prototype/app/templates/js/histogram_utils.js
+++ b/eorlive_prototype/app/templates/js/histogram_utils.js
@@ -1,0 +1,24 @@
+var getColumnRangeLimits = function(event, series) {
+    var absoluteIndex = event.point.index, relativeIndex = 0;
+
+    for (var i = 0; i < series.points.length; ++i) {
+        if (series.points[i].index === absoluteIndex) {
+            relativeIndex = i;
+            break;
+        }
+    }
+
+    var startTime = series.processedXData[relativeIndex], endTime = 0;
+
+    if (series.closestPointRange !== undefined) {
+        endTime = startTime + series.closestPointRange;
+    } else if (series.processedXData.length > relativeIndex + 1) {
+        endTime = series.processedXData[relativeIndex + 1];
+    } else if (series.xData.length > absoluteIndex + 1) {
+        endTime = series.xData[absoluteIndex + 1];
+    } else {
+        endTime = Date.parse("{{ range_end }}");
+    }
+
+    return { startTime: startTime, endTime: endTime };
+};

--- a/eorlive_prototype/app/templates/layout.html
+++ b/eorlive_prototype/app/templates/layout.html
@@ -25,14 +25,5 @@
         {% endfor %}
         {% block body %}{% endblock %}
     </div>
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
-    <script src="http://ajax.googleapis.com/ajax/libs/jqueryui/1.11.2/jquery-ui.min.js"></script>
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.0/js/bootstrap.min.js"></script>
-    <script src="../static/js/setsAndComments.js"></script>
-    {% if request.path == '/index' or request.path == '/' %}
-    <script src="../static/js/jquery.datetimepicker.js"></script>
-    <script src="../static/js/index.js"></script>
-    <script src="../static/js/highcharts.js"></script>
-    {% endif %}
 </body>
 </html>

--- a/eorlive_prototype/app/templates/profile.html
+++ b/eorlive_prototype/app/templates/profile.html
@@ -86,4 +86,5 @@
         });
     };
 </script>
+<script src="http://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
 {% endblock %}

--- a/eorlive_prototype/app/templates/setView.html
+++ b/eorlive_prototype/app/templates/setView.html
@@ -4,22 +4,177 @@
     <div id="main_content_row">
         <div id="left_content">
             <h1>{{ setName }}</h1>
-            Actual content will go here, like graphs and stuff
-            <br><br><br>
+            <button id='backbutton' onclick="backToHistogram()">Back to histogram</button>
+            <div id='error_table'></div>
+            <div id="set_histogram"></div>
             <button type="button" onclick="downloadSet()">Download set</button>
         </div>
         <div id="comments_div" class="comments_class"></div>
     </div>
 </div>
 <script src="http://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
-<script src="http://ajax.googleapis.com/ajax/libs/jqueryui/1.11.2/jquery-ui.min.js"></script>
 <script src="../static/js/setsAndComments.js"></script>
+<script src="../static/js/highcharts.js"></script>
+<script type="text/javascript">
+    {% include "js/histogram_utils.js" %} <!-- Because there are functions that depend on Python variables -->
+</script>
 <script>
     $(function() {
         renderComments('{{ setName }}');
     });
-</script>
-<script>
+
+    var observation_counts = {{ observation_counts | tojson }};
+    var error_counts = {{ error_counts | tojson }};
+    var plot_bands = {{ plot_bands | tojson }};
+
+    var backToHistogram = function() {
+        $('#backbutton').hide();
+        $('#error_table').hide();
+        $('#set_histogram').show();
+    };
+
+    $(function() {
+        $('#backbutton').hide();
+        $('#error_table').hide();
+        $('#set_histogram').html("<img src='/static/images/ajax-loader.gif' class='loading'/>");
+
+        $("#set_histogram").highcharts('StockChart', {
+            colors: [
+                '#7cb5ec',
+                '#FF0000',
+                '#90ed7d',
+                '#f7a35c',
+                '#8085e9',
+                '#f15c80',
+                '#e4d354',
+                '#8085e8',
+                '#8d4653',
+                '#91e8e1'
+            ],
+            credits: {
+                enabled: false,
+            },
+            chart: {
+                zoomType: "x",
+            },
+            legend: {
+                enabled: true
+            },
+            plotOptions: {
+                column: {
+                    dataGrouping: {
+                        groupPixelWidth: 100,
+                        forced: true
+                    },
+                    pointPlacement: "between",
+                    groupPadding: 0.1,
+                    pointPadding: 0,
+                    events: {
+                        click: function(event) {
+                            if (this.name === 'Errors') {
+                                var columnLimits = getColumnRangeLimits(event, this.xAxis.series[1]);
+                                var startTime = columnLimits.startTime, endTime = columnLimits.endTime;
+
+                                $('#set_histogram').hide();
+                                $('#error_table').html("<img src='/static/images/ajax-loader.gif' class='loading'/>");
+                                $('#error_table').show();
+
+                                $.ajax({
+                                    type: "POST",
+                                    url: "/error_table",
+                                    data: {
+                                        'starttime': startTime,
+                                        'endtime': endTime
+                                    },
+                                    success: function(data) {
+                                        $('#error_table').html(data);
+                                        $('#backbutton').show();
+                                    },
+                                    error: function(xhr, ajaxOptions, thrownError) {
+                                        backToHistogram();
+                                    },
+                                    dataType: "html"
+                                });
+                            }
+                        }
+                    }
+                }
+            },
+            rangeSelector: {
+                buttons: [{
+                    type: 'second',
+                    count: 1,
+                    text: '1s'
+                }, {
+                    type: 'minute',
+                    count: 1,
+                    text: '1min'
+                }, {
+                    type: 'minute',
+                    count: 60,
+                    text: '1hr'
+                }, {
+                    type: 'day',
+                    count: 1,
+                    text: '1d'
+                }, {
+                    type: 'week',
+                    count: 1,
+                    text: '1w'
+                }, {
+                    type: 'month',
+                    count: 1,
+                    text: '1mo'
+                }, {
+                    type: 'month',
+                    count: 3,
+                    text: '3mo'
+                }, {
+                    type: 'month',
+                    count: 6,
+                    text: '6mo'
+                }, {
+                    type: 'ytd',
+                    count: 1,
+                    text: 'YTD'
+                }, {
+                    type: 'year',
+                    count: 1,
+                    text: '1y'
+                }, {
+                    type: 'all',
+                    count: 1,
+                    text: 'all'
+                }],
+                selected: 10
+            },
+            title: {
+                text: 'Observation & Error Count'
+            },
+            xAxis: {
+                ordinal: false,
+                plotBands: plot_bands
+            },
+            yAxis: {
+                title: {
+                    text: 'Number of Observations/Errors'
+                },
+                min: 0,
+                allowDecimals: false
+            },
+            series: [{
+                type: 'column',
+                name: 'Observations',
+                data: observation_counts
+            },
+            {
+                type: 'column',
+                name: 'Errors',
+                data: error_counts
+            }]
+        });
+    });
+
     function saveCommentHelper() {
         var comment_text = document.getElementById("comment_text_field").value;
         if (comment_text.length > 1000) {

--- a/eorlive_prototype/app/templates/setView.html
+++ b/eorlive_prototype/app/templates/setView.html
@@ -9,7 +9,6 @@
             <div id="set_histogram"></div>
             <button type="button" onclick="downloadSet()">Download set</button>
         </div>
-        <div id="comments_div" class="comments_class"></div>
     </div>
 </div>
 <script src="http://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
@@ -19,10 +18,6 @@
     {% include "js/histogram_utils.js" %} <!-- Because there are functions that depend on Python variables -->
 </script>
 <script>
-    $(function() {
-        renderComments('{{ setName }}');
-    });
-
     var observation_counts = {{ observation_counts | tojson }};
     var error_counts = {{ error_counts | tojson }};
     var plot_bands = {{ plot_bands | tojson }};
@@ -174,27 +169,6 @@
             }]
         });
     });
-
-    function saveCommentHelper() {
-        var comment_text = document.getElementById("comment_text_field").value;
-        if (comment_text.length > 1000) {
-            alert("Please enter a string under 1000 characters. Your comment is " + (comment_text.length - 1000) + " characters too long.");
-        }
-        else if (!(comment_text)) //if it's empty, do nothing
-        {
-            //do nothing
-        }
-        else {
-            document.getElementById('comment_text_field').value = ""; //empty the box
-            saveComment({{set_id}}, comment_text);
-        }
-    }
-
-    function handle(e) {
-        if (e.keyCode === 13) {
-            saveCommentHelper();
-        }
-    }
 
     function downloadSet() {
         window.open("/download_set?set_id={{set_id}}", '_blank');

--- a/eorlive_prototype/app/templates/set_construction_panel.html
+++ b/eorlive_prototype/app/templates/set_construction_panel.html
@@ -37,6 +37,9 @@
         </table>
     </div>
 </div>
+<script type="text/javascript">
+    {% include "js/histogram_utils.js" %} <!-- Because there are functions that depend on Python variables -->
+</script>
 <script>
     var _chart;
     var inConstructionMode = false;
@@ -481,30 +484,5 @@
 
             removeAllPlotBands();
         }
-    };
-
-    var getColumnRangeLimits = function(event, series) {
-        var absoluteIndex = event.point.index, relativeIndex = 0;
-
-        for (var i = 0; i < series.points.length; ++i) {
-            if (series.points[i].index === absoluteIndex) {
-                relativeIndex = i;
-                break;
-            }
-        }
-
-        var startTime = series.processedXData[relativeIndex], endTime = 0;
-
-        if (series.closestPointRange !== undefined) {
-            endTime = startTime + series.closestPointRange;
-        } else if (series.processedXData.length > relativeIndex + 1) {
-            endTime = series.processedXData[relativeIndex + 1];
-        } else if (series.xData.length > absoluteIndex + 1) {
-            endTime = series.xData[absoluteIndex + 1];
-        } else {
-            endTime = Date.parse("{{ range_end }}");
-        }
-
-        return { startTime: startTime, endTime: endTime };
     };
 </script>

--- a/eorlive_prototype/app/views.py
+++ b/eorlive_prototype/app/views.py
@@ -6,7 +6,7 @@ import requests
 import json
 import hashlib
 from requests_futures.sessions import FuturesSession
-from sqlalchemy import and_, func, or_
+from sqlalchemy import and_
 from datetime import datetime, timedelta
 import psycopg2
 import os
@@ -298,7 +298,7 @@ def logout():
 def profile():
     if (g.user is not None and g.user.is_authenticated()):
         user = models.User.query.get(g.user.username)
-        setList = models.Set.query.filter(and_(models.Set.username == g.user.username))
+        setList = models.Set.query.filter(models.Set.username == g.user.username)
         return render_template('profile.html', user=user, sets=setList)
     else:
         return redirect(url_for('login'))
@@ -346,12 +346,12 @@ def delete_set():
         set_name = request.form['set_name']
         user = models.User.query.get(g.user.username)
 
-        theSet = models.Set.query.filter(and_(models.Set.name == set_name)).first()
+        theSet = models.Set.query.filter(models.Set.name == set_name).first()
 
         db.session.delete(theSet)
         db.session.commit()
 
-        setList = models.Set.query.filter(and_(models.Set.username == g.user.username))
+        setList = models.Set.query.filter(models.Set.username == g.user.username)
         return render_template('profile.html', user=user, sets=setList)
     else:
         return redirect(url_for('login'))

--- a/eorlive_prototype/app/views.py
+++ b/eorlive_prototype/app/views.py
@@ -1,7 +1,7 @@
 from flask import render_template, flash, redirect, session, url_for, request, g, make_response
 from flask.ext.login import login_user, logout_user, current_user, login_required
 from app.flask_app import app, lm, db
-from app import models
+from app import models, db_utils, histogram_utils
 import requests
 import json
 import hashlib
@@ -10,11 +10,6 @@ from sqlalchemy import and_, func, or_
 from datetime import datetime, timedelta
 import psycopg2
 import os
-
-def send_query(db, query):
-    cur = db.cursor()
-    cur.execute(query)
-    return cur
 
 @app.route('/')
 @app.route('/index')
@@ -27,19 +22,26 @@ def index(setName = None):
     if setName is not None:
         session = FuturesSession()
 
-        theSet = models.Set.query.filter(and_(models.Set.name == setName)).first()
+        theSet = models.Set.query.filter(models.Set.name == setName).first()
+
+        if theSet is None:
+            return render_template('index.html')
+
+        observation_counts = histogram_utils.get_observation_counts(theSet.start, theSet.end)
+        error_counts = histogram_utils.get_error_counts(theSet.start, theSet.end)[0]
+        plot_bands = histogram_utils.get_plot_bands(theSet)
 
         if (g.user is not None and g.user.is_authenticated()):
-            if theSet is not None:
-                comments = theSet.comments
-                if comments is not None:
-                    return render_template('setView.html', setName=theSet.name, comments=comments, set_id=theSet.id, setStart=theSet.start, setEnd=theSet.end)
-                else: #set with no comments
-                    return render_template('setView.html', setName=theSet.name, set_id=theSet.id, setStart=theSet.start, setEnd=theSet.end)
-            else: #no set, just show index
-                return render_template('index.html')
+            comments = theSet.comments
+            if comments is not None:
+                return render_template('setView.html', setName=theSet.name, comments=comments, set_id=theSet.id,setStart=theSet.start, setEnd=theSet.end, observation_counts=observation_counts,
+                error_counts=error_counts, plot_bands=plot_bands, range_end=theSet.end)
+            else: #set with no comments
+                return render_template('setView.html', setName=theSet.name, set_id=theSet.id, setStart=theSet.start,setEnd=theSet.end, observation_counts=observation_counts, error_counts=error_counts,
+                plot_bands=plot_bands, range_end=theSet.end)
         else: #logged out view
-            return render_template('setView.html', setName=theSet.name, set_id=theSet.id, setStart=theSet.start, setEnd=theSet.end, logged_out=True)
+            return render_template('setView.html', setName=theSet.name, set_id=theSet.id, setStart=theSet.start, setEnd=theSet.end, logged_out=True, observation_counts=observation_counts, error_counts=error_counts,
+            plot_bands=plot_bands, range_end=theSet.end)
     else: #original case in index
         return render_template('index.html', starttime=request.args.get('starttime'), endtime=request.args.get('endtime'))
 
@@ -99,27 +101,11 @@ def histogram_data():
     #Wait for the second request to complete, if it hasn't already.
     end_gps = int(future_end.result().content)
 
-    leap_seconds_result = send_query(g.eor_db, "SELECT leap_seconds FROM leap_seconds ORDER BY leap_seconds DESC LIMIT 1").fetchone()
-
-    leap_seconds = leap_seconds_result[0]
-
-    GPS_LEAP_SECONDS_OFFSET = leap_seconds - 19
-
-    response = send_query(g.eor_db, '''SELECT starttime, obsname, ra_phase_center
+    response = db_utils.send_query(g.eor_db, '''SELECT starttime, obsname, ra_phase_center
                     FROM mwa_setting
                     WHERE starttime >= {} AND starttime <= {}
                     AND projectid='G0009'
                     ORDER BY starttime ASC'''.format(start_gps, end_gps)).fetchall()
-
-    obscontroller_response = send_query(g.eor_db, '''SELECT FLOOR(reference_time) AS reference_time
-                            FROM obscontroller_log
-                            WHERE reference_time >= {} AND reference_time <= {}
-                            ORDER BY reference_time ASC'''.format(start_gps, end_gps)).fetchall()
-
-    recvstatuspolice_response = send_query(g.eor_db, '''SELECT FLOOR(reference_time) AS reference_time
-                            FROM recvstatuspolice_log
-                            WHERE reference_time >= {} AND reference_time <= {}
-                            ORDER BY reference_time ASC'''.format(start_gps, end_gps)).fetchall()
 
     # The Julian day for January 1, 2000 12:00 UT was 2,451,545 (http://en.wikipedia.org/wiki/Julian_day).
     jan_1_2000 = datetime(2000, 1, 1, 12)
@@ -134,12 +120,6 @@ def histogram_data():
 
     julian_day_end = delta_end.days + jan_1_2000_julian_day
 
-    jan_1_1970 = datetime(1970, 1, 1)
-
-    jan_6_1980 = datetime(1980, 1, 6)
-
-    GPS_UTC_DELTA = (jan_6_1980 - jan_1_1970).total_seconds()
-
     low_eor0_counts = []
 
     high_eor0_counts = []
@@ -148,7 +128,7 @@ def histogram_data():
 
     high_eor1_counts = []
 
-    error_counts = []
+    error_counts, error_count = histogram_utils.get_error_counts(start_gps, end_gps)
 
     julian_days = [x for x in range(julian_day_start, julian_day_end + 1)]
     #Wait for this Web request to complete, if it hasn't already.
@@ -156,7 +136,7 @@ def histogram_data():
 
     SECONDS_PER_DAY = 86400
 
-    low_eor0_count = high_eor0_count = low_eor1_count = high_eor1_count = error_count = 0
+    low_eor0_count = high_eor0_count = low_eor1_count = high_eor1_count = 0
 
     prev_low_eor0_time = prev_high_eor0_time = prev_low_eor1_time = prev_high_eor1_time = 0
 
@@ -166,6 +146,8 @@ def histogram_data():
     utc_obsid_map_h1 = []
 
     prev_high_time = prev_low_time = 0
+
+    GPS_LEAP_SECONDS_OFFSET, GPS_UTC_DELTA = db_utils.get_gps_utc_constants()
 
     for observation in response:
         obs_counts_index = 0
@@ -221,30 +203,6 @@ def histogram_data():
                 high_eor1_count += 1
                 utc_obsid_map_h1.append([utc_millis, int(observation[0])])
 
-    prev_time = 0
-
-    for error in obscontroller_response:
-        utc_millis = int((error[0] - GPS_LEAP_SECONDS_OFFSET + GPS_UTC_DELTA) * 1000)
-        if utc_millis == prev_time:
-            error_counts[-1][1] += 1
-        else:
-            error_counts.append([utc_millis, 1])
-            prev_time = utc_millis
-        error_count += 1
-
-    prev_time = 0
-
-    for error in recvstatuspolice_response:
-        utc_millis = int((error[0] - GPS_LEAP_SECONDS_OFFSET + GPS_UTC_DELTA) * 1000)
-        if utc_millis == prev_time:
-            error_counts[-1][1] += 1
-        else:
-            error_counts.append([utc_millis, 1])
-            prev_time = utc_millis
-        error_count += 1
-
-    error_counts.sort(key=lambda error: error[0])
-
     return render_template('histogram.html', julian_days=julian_days,
         low_eor0_counts=low_eor0_counts, high_eor0_counts=high_eor0_counts,
         low_eor1_counts=low_eor1_counts, high_eor1_counts=high_eor1_counts,
@@ -281,12 +239,12 @@ def error_table():
     #Wait for the second request to complete, if it hasn't already.
     end_gps = int(future_end.result().content)
 
-    obscontroller_response = send_query(g.eor_db, '''SELECT reference_time, observation_number, comment
+    obscontroller_response = db_utils.send_query(g.eor_db, '''SELECT reference_time, observation_number, comment
                             FROM obscontroller_log
                             WHERE reference_time >= {} AND reference_time < {}
                             ORDER BY reference_time ASC'''.format(start_gps, end_gps)).fetchall()
 
-    recvstatuspolice_response = send_query(g.eor_db, '''SELECT reference_time, observation_number, comment
+    recvstatuspolice_response = db_utils.send_query(g.eor_db, '''SELECT reference_time, observation_number, comment
                             FROM recvstatuspolice_log
                             WHERE reference_time >= {} AND reference_time < {}
                             ORDER BY reference_time ASC'''.format(start_gps, end_gps)).fetchall()

--- a/eorlive_prototype/app/views.py
+++ b/eorlive_prototype/app/views.py
@@ -32,16 +32,13 @@ def index(setName = None):
         plot_bands = histogram_utils.get_plot_bands(theSet)
 
         if (g.user is not None and g.user.is_authenticated()):
-            comments = theSet.comments
-            if comments is not None:
-                return render_template('setView.html', setName=theSet.name, comments=comments, set_id=theSet.id,setStart=theSet.start, setEnd=theSet.end, observation_counts=observation_counts,
+            return render_template('setView.html', setName=theSet.name, set_id=theSet.id,
+                setStart=theSet.start, setEnd=theSet.end, observation_counts=observation_counts,
                 error_counts=error_counts, plot_bands=plot_bands, range_end=theSet.end)
-            else: #set with no comments
-                return render_template('setView.html', setName=theSet.name, set_id=theSet.id, setStart=theSet.start,setEnd=theSet.end, observation_counts=observation_counts, error_counts=error_counts,
-                plot_bands=plot_bands, range_end=theSet.end)
         else: #logged out view
-            return render_template('setView.html', setName=theSet.name, set_id=theSet.id, setStart=theSet.start, setEnd=theSet.end, logged_out=True, observation_counts=observation_counts, error_counts=error_counts,
-            plot_bands=plot_bands, range_end=theSet.end)
+            return render_template('setView.html', setName=theSet.name, set_id=theSet.id, setStart=theSet.start,
+                setEnd=theSet.end, logged_out=True, observation_counts=observation_counts, error_counts=error_counts,
+                plot_bands=plot_bands, range_end=theSet.end)
     else: #original case in index
         return render_template('index.html', starttime=request.args.get('starttime'), endtime=request.args.get('endtime'))
 
@@ -343,25 +340,6 @@ def get_sets():
     else:
         return render_template('setList.html', logged_out=True)
 
-@app.route('/save_comment', methods = ['POST'])
-def save_comment():
-    if (g.user is not None and g.user.is_authenticated()):
-        set_id = request.form['set_id']
-        comment_text = request.form['comment_text']
-
-        theSet = models.Set.query.get(set_id)
-
-        #now, add the comment
-        com = models.Comment()
-        com.text = comment_text
-        com.username = g.user.username
-        com.set_id = set_id
-
-        theSet.comments.append(com)
-        db.session.commit()
-
-        return render_template('comments.html', comments=theSet.comments, set_id=theSet.id)
-
 @app.route('/delete_set', methods = ['POST'])
 def delete_set():
     if (g.user is not None and g.user.is_authenticated()):
@@ -377,8 +355,3 @@ def delete_set():
         return render_template('profile.html', user=user, sets=setList)
     else:
         return redirect(url_for('login'))
-
-@app.route('/get_comments', methods = ['POST'])
-def get_comments():
-    theSet = models.Set.query.filter(and_(models.Set.name == request.form['set_name'])).first()
-    return render_template('comments.html', comments=theSet.comments)

--- a/eorlive_prototype/run_app.py
+++ b/eorlive_prototype/run_app.py
@@ -1,7 +1,7 @@
 #!flask/bin/python
 
 from app.flask_app import app
-from app import views, models, sets
+from app import views, models, sets, comments
 
 if __name__ == "__main__":
     app.run(debug=True, host='0.0.0.0')


### PR DESCRIPTION
Now there's a graph on the set view page and instead of being tied to sets, comments are generalized and organized into threads on the main page.
![commentsfinal](https://cloud.githubusercontent.com/assets/4495447/6720889/f05e6158-cd84-11e4-8095-11699d826829.png)
![setviewpage](https://cloud.githubusercontent.com/assets/4495447/6720893/f43cd1ba-cd84-11e4-820a-913a8e612768.png)

